### PR TITLE
fix: replace deprecated lodash.isequal

### DIFF
--- a/src/helpers/images.ts
+++ b/src/helpers/images.ts
@@ -1,5 +1,5 @@
 import uniqWith from 'lodash.uniqwith';
-import isEqual from 'lodash.isequal';
+import { isDeepStrictEqual as isEqual } from 'node:util';
 import constants from '../config/constants';
 import { Image, Orientation } from '../models/image';
 import { LaunchScreenSpec } from '../models/spec';


### PR DESCRIPTION
This pull request includes a change to the `src/helpers/images.ts` file. The change replaces the `lodash.isequal` import with the `isDeepStrictEqual` method from Node.js's `util` module.

* [`src/helpers/images.ts`](diffhunk://#diff-33c1d328924b0a23039173a977541c9f86487072ede15d226d08e66cf013abe8L2-R2): Replaced `lodash.isequal` import with `isDeepStrictEqual` from `node:util` for deep equality checks.lodash.isequal@4.5.0: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.