### PR TITLE
feat(core): replace `chalk` with `picocolors`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "8.0.5",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.4.1",
         "cheerio": "^1.0.0",
         "chrome-launcher": "^1.1.2",
         "find-process": "^1.4.10",
         "lodash.uniqwith": "^4.5.0",
         "meow": "^13.2.0",
         "mime-types": "^3.0.1",
+        "picocolors": "^1.1.1",
         "pretty": "^2.0.0",
         "puppeteer-core": "^24.4.0",
         "slash": "^5.1.0"
@@ -3798,6 +3798,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
       "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -11092,7 +11093,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -15839,7 +15839,8 @@
     "chalk": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true
     },
     "char-regex": {
       "version": "1.0.2",
@@ -20695,8 +20696,7 @@
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -69,13 +69,13 @@
     "url": "https://opencollective.com/pwa-asset-generator"
   },
   "dependencies": {
-    "chalk": "^5.4.1",
     "cheerio": "^1.0.0",
     "chrome-launcher": "^1.1.2",
     "find-process": "^1.4.10",
     "lodash.uniqwith": "^4.5.0",
     "meow": "^13.2.0",
     "mime-types": "^3.0.1",
+    "picocolors": "^1.1.1",
     "pretty": "^2.0.0",
     "puppeteer-core": "^24.4.0",
     "slash": "^5.1.0"

--- a/src/helpers/logger.ts
+++ b/src/helpers/logger.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import pc from 'picocolors';
 import type { Logger } from '../models/logger.js';
 import type { CLIOptions } from '../models/options.js';
 
@@ -8,9 +8,9 @@ const logger: Logger = (prefix: string, options?: CLIOptions) => {
   const isLogEnabled =
     options && options.hasOwnProperty('log') ? options.log : true;
 
-  const getTime = (): string => chalk.inverse(new Date().toLocaleTimeString());
+  const getTime = (): string => pc.inverse(new Date().toLocaleTimeString());
 
-  const getPrefix = (): string => (prefix ? chalk.gray(prefix) : '');
+  const getPrefix = (): string => (prefix ? pc.gray(prefix) : '');
 
   const raw = (...args: string[]): void => {
     if (!isLogEnabled) return;
@@ -24,7 +24,12 @@ const logger: Logger = (prefix: string, options?: CLIOptions) => {
 
   const warn = (...args: string[]): void => {
     if (testMode || !isLogEnabled) return;
-    console.warn(getTime(), getPrefix(), chalk.yellow(...args), '🤔');
+    console.warn(
+      getTime(),
+      getPrefix(),
+      args.map((arg) => pc.yellow(arg)),
+      '🤔',
+    );
   };
 
   const trace = (...args: string[]): void => {
@@ -33,12 +38,22 @@ const logger: Logger = (prefix: string, options?: CLIOptions) => {
   };
 
   const error = (...args: string[]): void => {
-    console.error(getTime(), getPrefix(), chalk.red(...args), '😭');
+    console.error(
+      getTime(),
+      getPrefix(),
+      args.map((arg) => pc.red(arg)),
+      '😭',
+    );
   };
 
   const success = (...args: string[]): void => {
     if (testMode || !isLogEnabled) return;
-    console.log(getTime(), getPrefix(), chalk.green(...args), '🙌');
+    console.log(
+      getTime(),
+      getPrefix(),
+      args.map((arg) => pc.green(arg)),
+      '🙌',
+    );
   };
 
   return {


### PR DESCRIPTION
This PR replaces chalk with picocolors, a lightweight alternative to chalk. This will reduce install footprint as well as installation time, which is perhaps even more important than the former, as pwa-asset-generator is commonly used with `npx` and `yarn dlx`.