### PR TITLE
chore(core): refactor spreads in accumulators

### DIFF
--- a/src/helpers/flags.ts
+++ b/src/helpers/flags.ts
@@ -39,18 +39,22 @@ const getDefaultOptions = (): Options => {
     { type: string; alias: string; default?: string | number | boolean }
   >;
 
-  // TODO: replace Object.keys typecasting when it can be derived as a type
-  // https://github.com/microsoft/TypeScript/pull/12253#issuecomment-263132208
-  return Object.keys(flags)
-    .filter((flagKey) =>
-      flags[flagKey as keyof Options].hasOwnProperty('default'),
-    )
-    .reduce((acc: Options, curr: string | keyof Options) => {
-      return {
-        ...acc,
-        [curr]: flags[curr as keyof Options].default,
-      };
-    }, {} as Options);
+  return Object.keys(flags).reduce(
+    (acc, curr) => {
+      const flagKey = curr as keyof Options;
+
+      if (flags[flagKey].hasOwnProperty('default')) {
+        const val = flags[flagKey].default;
+
+        if (val) {
+          acc[flagKey] = val;
+        }
+      }
+
+      return acc;
+    },
+    {} as Record<keyof Options, Options[keyof Options]>,
+  ) as Options;
 };
 
 const normalizeSandboxOption = (

--- a/src/helpers/puppets.ts
+++ b/src/helpers/puppets.ts
@@ -92,20 +92,16 @@ const getAppleSplashScreenData = async (
         return columns.reduce(
           (acc, curr: HTMLElement, index) => {
             if (index === 0) {
-              return {
-                ...acc,
-                device: curr.innerText,
-              };
+              acc.device = curr.innerText;
+              return acc;
             }
 
             const specs = getParsedSpecs(curr.innerText.trim());
 
-            return {
-              ...acc,
-              portrait: { width: specs.width, height: specs.height },
-              landscape: { width: specs.height, height: specs.width },
-              scaleFactor: specs.scaleFactor,
-            };
+            acc.portrait = { width: specs.width, height: specs.height };
+            acc.landscape = { width: specs.height, height: specs.width };
+            acc.scaleFactor = specs.scaleFactor;
+            return acc;
           },
           {
             device: '',


### PR DESCRIPTION
Using spread in accumulators like .reduce() may result in degraded performance as you create new object with every iteration. This is rarely needed. This refactors the code to avoid spread in accumulators and while at it, removes a TODO that will never resolve for the reasons stated in the discussion in the link I removed.