### PR TITLE
chore(chore): fix sneaky implicit `any`s

### DIFF
--- a/src/helpers/browser.ts
+++ b/src/helpers/browser.ts
@@ -14,6 +14,14 @@ import type {
 // Used for both launch and connect options
 type PuppeteerOptions = LaunchOptions & ConnectOptions;
 
+interface RevisionInfo {
+  folderPath: string;
+  executablePath: string;
+  local: boolean;
+  revision: string;
+  url?: string;
+}
+
 interface BrowserVersionInfo {
   Browser: string;
   webSocketDebuggerUrl: string;
@@ -44,7 +52,7 @@ const getLocalBrowserInstance = async (
   launchArgs: PuppeteerOptions,
   noSandbox: boolean,
 ): Promise<Browser> => {
-  let revisionInfo;
+  let revisionInfo: RevisionInfo;
   const localRevisionInfo = await getLocalRevisionInfo();
 
   if (localRevisionInfo) {

--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -32,7 +32,7 @@ const convertBackslashPathToSlashPath = (backSlashPath: string): string =>
   slash(backSlashPath);
 
 const getAppDir = (): string => {
-  let appPath;
+  let appPath: string | undefined;
   try {
     appPath = require.resolve('pwa-asset-generator');
   } catch (e) {

--- a/src/helpers/puppets.ts
+++ b/src/helpers/puppets.ts
@@ -145,7 +145,7 @@ const getSplashScreenMetaData = async (
     '🤖',
   );
 
-  let splashScreenMetaData;
+  let splashScreenMetaData: LaunchScreenSpec[];
 
   try {
     splashScreenMetaData = await getAppleSplashScreenData(browser, options);
@@ -270,7 +270,7 @@ const generateImages = async (
     isHtmlInput ? false : options.noSandbox,
   );
 
-  let splashScreenMetaData;
+  let splashScreenMetaData: LaunchScreenSpec[];
 
   try {
     splashScreenMetaData = await getSplashScreenMetaData(options, browser);

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -7,6 +7,8 @@ import { describe, test, expect, beforeEach } from 'vitest';
 import type { ManifestJsonIcon, Result } from './models/result.js';
 import type { CLIOptions } from './models/options.js';
 import type { SavedImage } from './models/image.js';
+import type { PNGWithMetadata } from 'pngjs';
+import type { BufferRet } from 'jpeg-js';
 
 const generateTempImages = (
   options: CLIOptions,
@@ -455,8 +457,8 @@ describe('visually compares generated images with', async () => {
     fileBPath: string,
   ): VisualDiffResult => {
     const isPNG = fileAPath.endsWith('.png');
-    let imgA;
-    let imgB;
+    let imgA: PNGWithMetadata | BufferRet;
+    let imgB: PNGWithMetadata | BufferRet;
 
     if (isPNG) {
       imgA = PNG.sync.read(file.readFileSync(fileAPath));


### PR DESCRIPTION
Some variables were initialized without type, resulting in implicit `any`. While the code that came after was written just fine and did not cause any type errors further down the line, this was the result of pure luck  (and skill!). With this PR, TypeScript can do its job in these places.