### PR TITLE
chore(test): disable globals in Vitest

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,10 +13,7 @@ export default [
     files: ['**/*.js'],
     ignores: ['dist/**', 'node_modules/**'],
     languageOptions: {
-      globals: {
-        ...globals.node,
-        ...globals.browser,
-      },
+      globals: globals.node,
     },
     rules: {
       // Error prevention
@@ -97,7 +94,6 @@ export default [
       },
       globals: {
         ...globals.node,
-        ...globals.browser,
         NodeModule: 'readonly',
       },
     },
@@ -132,18 +128,7 @@ export default [
     },
     languageOptions: {
       parser: tsParser,
-      globals: {
-        ...globals.node,
-        ...globals.browser,
-        vi: 'readonly',
-        describe: 'readonly',
-        it: 'readonly',
-        expect: 'readonly',
-        beforeEach: 'readonly',
-        afterEach: 'readonly',
-        beforeAll: 'readonly',
-        afterAll: 'readonly',
-      },
+      globals: globals.node,
     },
     rules: {
       ...tseslint.configs.recommended.rules,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,11 +4,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],
-    globals: true,
     setupFiles: ['./vitest.setup.ts'],
-    transformMode: {
-      web: [/\.[jt]sx?$/],
-    },
     testTimeout: 120000,
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,3 +1,5 @@
+import { vi } from 'vitest';
+
 // Set a longer timeout for tests
 const TEST_TIMEOUT_IN_MILLIS = 120000;
 


### PR DESCRIPTION
It seems like you've decided to use Vitest globals function in ONE place only, which led to ESLint config longer than it needs to be, so I just went ahead and disabled that option and disallowed Vitest globals. Additionally, transformMode does not exist in Vitest, so it had no effect, so I removed it as well.